### PR TITLE
Added missing space in date pattern

### DIFF
--- a/src/main/java/liqp/filters/Date.java
+++ b/src/main/java/liqp/filters/Date.java
@@ -15,7 +15,7 @@ class Date extends Filter {
 
     static {
         addDatePattern("yyyy-MM-dd HH:mm:ss");
-        addDatePattern("EEE MMM ddhh:mm:ss yyyy");
+        addDatePattern("EEE MMM dd hh:mm:ss yyyy");
         init();
     }
 


### PR DESCRIPTION
A missing space in the date pattern "EEE MMM ddhh:mm:ss yyyy" made the date filter ineffective in some cases.